### PR TITLE
adding `readyOnLoad` fix to still call `load` callback

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,11 @@
+0.1.5 - November 26, 2013
+-------------------------
+* adding `readyOnLoad` fix to still call `load` callback
+
+0.1.4 - November 12, 2013
+-------------------------
+* debug: upgrade to 0.7.3
+
 0.1.2 - November 11, 2013
 -------------------------
 * rename `section` argument to `category`
@@ -5,7 +13,7 @@
 0.1.1 - November 11, 2013
 -------------------------
 * add `section` argument to `page` method signature
- 
+
 0.1.0 - November 10, 2013
 -------------------------
 * change `exists` to `loaded` and check in `load`

--- a/component.json
+++ b/component.json
@@ -2,7 +2,7 @@
   "name": "integration",
   "repo": "segmentio/analytics.js-integration",
   "description": "The base integration factory used to create custom analytics integrations for analytics.js.",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "keywords": ["analytics.js", "integration", "analytics"],
   "dependencies": {
     "avetisk/defaults": "0.0.4",

--- a/lib/protos.js
+++ b/lib/protos.js
@@ -164,12 +164,10 @@ exports._wrapLoad = function () {
 
     if (this.loaded()) {
       this.debug('already loaded');
-      if (self._readyOnLoad) {
-        tick(function () {
-          self.emit('ready');
-          callback && callback();
-        });
-      }
+      tick(function () {
+        if (self._readyOnLoad) self.emit('ready');
+        callback && callback();
+      });
       return;
     }
 

--- a/test/index.js
+++ b/test/index.js
@@ -217,6 +217,13 @@ describe('integration', function () {
       integration.load();
     });
 
+    it('should callback if the integration is already loaded, but not `readyOnLoad`', function (done) {
+      var NotReadyOnLoad = createIntegration('Name');
+      integration = new NotReadyOnLoad();
+      integration.loaded = function () { return true; };
+      integration.load(done);
+    });
+
     it('should callback', function (done) {
       integration.load(done);
     });


### PR DESCRIPTION
I had the problem where one of my integrations wasn't marked `readyOnLoad()`
and instead did some setup after the load callback before emitting `ready`.

``` js
Integration.prototype.initialize = function () {
  var self = this;
  this.load(function () {
    // ...
    self.emit('ready');
  });
};
```

This fixes the load callback so that it will actually get called.
