### PR TITLE
add initial ecommerce

### DIFF
--- a/component.json
+++ b/component.json
@@ -19,11 +19,13 @@
     "ianstormtaylor/assert": "*",
     "ianstormtaylor/sinon": "*",
     "jkroso/equals": "*",
+    "segmentio/analytics.js-integration-tester": "*",
     "timoxley/next-tick": "*"
   },
   "scripts": [
     "lib/index.js",
     "lib/protos.js",
+    "lib/events.js",
     "lib/statics.js"
   ],
   "main": "lib/index.js"

--- a/lib/events.js
+++ b/lib/events.js
@@ -1,0 +1,11 @@
+
+/**
+ * Expose `events`
+ */
+
+module.exports = {
+  removedProduct: /removed product/i,
+  viewedProduct: /viewed product/i,
+  addedProduct: /added product/i,
+  checkedOut: /checked out/i
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -40,6 +40,7 @@ function createIntegration (name) {
     this._wrapInitialize();
     this._wrapLoad();
     this._wrapPage();
+    this._wrapTrack();
   }
 
   Integration.prototype.defaults = {};

--- a/lib/protos.js
+++ b/lib/protos.js
@@ -3,6 +3,7 @@ var after = require('after');
 var callback = require('callback');
 var Emitter = require('emitter');
 var tick = require('next-tick');
+var events = require('./events');
 
 
 /**
@@ -10,7 +11,6 @@ var tick = require('next-tick');
  */
 
 Emitter(exports);
-
 
 /**
  * Initialize.
@@ -47,14 +47,18 @@ exports.load = function (cb) {
 /**
  * Page.
  *
- * @param {String} category (optional)
- * @param {String} name (optional)
- * @param {Object} properties (optional)
- * @param {Object} options (optional)
+ * @param {Page} page
  */
 
-exports.page = function (category, name, properties, options) {};
+exports.page = function(page){};
 
+/**
+ * Track.
+ *
+ * @param {Track} track
+ */
+
+exports.track = function(track){};
 
 /**
  * Invoke a `method` that may or may not exist on the prototype with `args`,
@@ -200,5 +204,32 @@ exports._wrapPage = function () {
       });
     }
     page.apply(this, arguments);
+  };
+};
+
+/**
+ * Wrap the track method to call other ecommerce methods if
+ * available depending on the `track.event()`.
+ *
+ * @api private
+ */
+
+exports._wrapTrack = function(){
+  var t = this.track;
+  this.track = function(track){
+    if (!this._ready) return this.queue('track', arguments);
+    var event = track.event();
+    var called;
+
+    for (var method in events) {
+      var regexp = events[method];
+      if (!this[method]) continue;
+      if (!regexp.test(event)) continue;
+      this[method].call(this, track);
+      called = true;
+      break;
+    }
+
+    if (!called) t.call(this, track);
   };
 };


### PR DESCRIPTION
@ianstormtaylor, @DirtyAnalytics 

method name, regexp:

``` js
['addedProduct', /added product/i]
['removedProduct', /removed product/i]
['viewedProduct', /viewed product/i]
['checkedout', /checked out/i]
```

i didn't go crazy and used `obj-case` because i don't want to promote users to go crazy with event names and "we'll take care of it", because i think they should follow the docs.

also `addedProduct` is kinda lame because camelcase is lame, so if you want them to be `added`, `removed`, `viewed` i'll be happy to change that, the reason i appended `product` is because we might use `added`, `removed` in the future.
