### PR TITLE
add .mapping(name)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -42,6 +42,10 @@ Custom.prototype.track = function (event, properties) {
 
   Mark the `Integration` as being ready after `load` is called. This is true for integrations that need to wait for their library to load to record data.
 
+### .mapping(name)
+
+  Create mapping method with `name`, this will default an option to `[]`, to learn more about mappings see `#events` method as an example.
+
 ### #initialize([page])
   
   Initialize the integration. This is where the typical 3rd-party Javascript snippet logic should be. If the integration assumes an initial pageview, `initialize` will be called with the `page` method's arguments.
@@ -56,7 +60,7 @@ Custom.prototype.track = function (event, properties) {
 //
 
 var MyIntegration = Integration('MyIntegration')
-  .option('events', []);
+  .mapping('events');
 
 //
 // In Our UI the user has those options:

--- a/lib/protos.js
+++ b/lib/protos.js
@@ -71,16 +71,16 @@ exports.track = function(track){};
  * 
  * Examples:
  * 
- *    { my_event: 'a4991b88' }
- *    .track('My Event');
+ *    events = { my_event: 'a4991b88' }
+ *    .map(events, 'My Event');
  *    // => ["a4991b88"]
- *    .track('whatever');
+ *    .map(events, 'whatever');
  *    // => []
  * 
- *    [{ key: 'my event', value: '9b5eb1fa' }]
- *    .track('my_event');
+ *    events = [{ key: 'my event', value: '9b5eb1fa' }]
+ *    .map(events, 'my_event');
  *    // => ["9b5eb1fa"]
- *    .track('whatever');
+ *    .map(events, 'whatever');
  *    // => []
  * 
  * @param {String} str
@@ -88,30 +88,29 @@ exports.track = function(track){};
  * @api public
  */
 
-exports.events = function(str){
-  var events = this.options.events;
+exports.map = function(obj, str){
   var a = normalize(str);
   var ret = [];
 
-  // no events
-  if (!events) return ret;
+  // noop
+  if (!obj) return ret;
 
   // object
-  if ('object' == type(events)) {
-    for (var k in events) {
-      var item = events[k];
+  if ('object' == type(obj)) {
+    for (var k in obj) {
+      var item = obj[k];
       var b = normalize(k);
       if (b == a) ret.push(item);
     }
   }
 
   // array
-  if ('array' == type(events)) {
-    if (!events.length) return ret;
-    if (!events[0].key) return ret;
+  if ('array' == type(obj)) {
+    if (!obj.length) return ret;
+    if (!obj[0].key) return ret;
 
-    for (var i = 0; i < events.length; ++i) {
-      var item = events[i];
+    for (var i = 0; i < obj.length; ++i) {
+      var item = obj[i];
       var b = normalize(item.key);
       if (b == a) ret.push(item.value);
     }

--- a/lib/statics.js
+++ b/lib/statics.js
@@ -23,6 +23,35 @@ exports.option = function (key, value) {
   return this;
 };
 
+/**
+ * Add a new mapping option.
+ * 
+ * the method will create a method `name` that will return a mapping
+ * for you to use.
+ * 
+ * Example:
+ * 
+ *    Integration('My Integration')
+ *      .mapping('events');
+ * 
+ *    new MyIntegration().track('My Event');
+ * 
+ *    .track = function(track){
+  *      var events = this.events(track.event());
+  *      each(events, send);
+ *     };
+ * 
+ * @param {String} name
+ * @return {Integration}
+ * @api public
+ */
+
+exports.mapping = function(name){
+  this.option(name, []);
+  this.prototype[name] = function(str){
+    return this.map(this.options[name], str);
+  };
+};
 
 /**
  * Register a new global variable `key` owned by the integration, which will be

--- a/test/index.js
+++ b/test/index.js
@@ -142,6 +142,21 @@ describe('integration', function () {
     });
   });
 
+  describe('.mapping', function(){
+    it('should create a mapping method', function(){
+      Integration.mapping('events');
+      var integration = new Integration;
+      integration.options.events = { a: 'b' };
+      assert.deepEqual(['b'], integration.events('a'));
+    })
+
+    it('should set an option to `[]`', function(){
+      Integration.mapping('events');
+      var integration = new Integration;
+      assert.deepEqual([], integration.options.events);
+    })
+  })
+
   describe('#emit', function () {
     it('should be mixed in', function () {
       assert(Integration.prototype.emit);
@@ -333,48 +348,48 @@ describe('integration', function () {
     })
   });
 
-  describe('#events', function(){
-    describe('when options.events is an object', function(){
+  describe('#map', function(){
+    describe('when `obj` is an object', function(){
       it('should return an empty array on mismatch', function(){
-        integration.options.events = { a: '4be41523', b: 'd49ccea' };
-        assert.deepEqual([], integration.events('c'));
+        var obj = { a: '4be41523', b: 'd49ccea' };
+        assert.deepEqual([], integration.map(obj, 'c'));
       })
 
       it('should return an array with the value on match', function(){
-        integration.options.events = { a: '48dc32b2', b: '48dc32b2' };
-        assert.deepEqual(['48dc32b2'], integration.events('b'));
+        var obj = { a: '48dc32b2', b: '48dc32b2' };
+        assert.deepEqual(['48dc32b2'], integration.map(obj, 'b'));
       })
 
       it('should use to-no-case to match keys', function(){
-        integration.options.events = { 'My Event': '7b4fe803', 'other event': '2107007a' };
-        assert.deepEqual(['7b4fe803'], integration.events('my_event'));
+        var obj = { 'My Event': '7b4fe803', 'other event': '2107007a' };
+        assert.deepEqual(['7b4fe803'], integration.map(obj, 'my_event'));
       })
     })
 
     describe('when .options.events is an array', function(){
       it('should return an empty array if the array isnt a map', function(){
-        integration.options.events = ['one', 'two'];
-        assert.deepEqual([], integration.events('one'));
+        var obj = ['one', 'two'];
+        assert.deepEqual([], integration.map(obj, 'one'));
       })
 
       it('should return an empty array when the array is empty', function(){
-        integration.options.events = [];
-        assert.deepEqual([], integration.events('wee'));
+        var obj = [];
+        assert.deepEqual([], integration.map(obj, 'wee'));
       })
 
       it('should return an empty array on mismatch', function(){
-        integration.options.events = [{ key: 'my event', value: '1121f10f' }];
-        assert([], integration.events('event'));
+        var obj = [{ key: 'my event', value: '1121f10f' }];
+        assert([], integration.map(obj, 'event'));
       })
 
       it('should return all matches in the array', function(){
-        integration.options.events = [{ key: 'baz', value: '4cff6219' }, { key: 'baz', value: '4426d54'} ];
-        assert(['4cff6219', '4426d54'], integration.events('baz'));
+        var obj = [{ key: 'baz', value: '4cff6219' }, { key: 'baz', value: '4426d54'} ];
+        assert(['4cff6219', '4426d54'], integration.map(obj, 'baz'));
       })
 
       it('should use to-no-case to match keys', function(){
-        integration.options.events = [{ key: 'My Event', value: 'a35bd696' }];
-        assert(['a35bd696'], integration.events('my_event'));
+        var obj = [{ key: 'My Event', value: 'a35bd696' }];
+        assert(['a35bd696'], integration.map(obj, 'my_event'));
       })
     })
   })


### PR DESCRIPTION
i realized that [some](https://github.com/segmentio/analytics.js-integrations/blob/master/lib/bing-ads.js#L27) integrations name the `.events` differently, while [other](https://github.com/segmentio/analytics.js-integrations/blob/master/lib/curebit.js#L54) integrations use mappings for different things.

just added a `.mapping(name)` static method that will add `proto[name]` method that will do what `.events(str)` did.

for example curebit would use `.campaigns(name)` and bing would use `.goals(goal)`, maybe we should consider even namespacing them ? like `.map.goals(str)` ?

LMK what you think

cc @ianstormtaylor 
