### PR TITLE
reset(): restore onerror

### DIFF
--- a/lib/protos.js
+++ b/lib/protos.js
@@ -21,7 +21,7 @@ var fmt = require('fmt');
 
 var setTimeout = window.setTimeout;
 var setInterval = window.setInterval;
-var onerror = null;
+var onerror = window.onerror;
 var onload = null;
 
 /**

--- a/test/index.js
+++ b/test/index.js
@@ -494,6 +494,7 @@ describe('integration', function(){
     it('should reset window defaults', function(){
       var setTimeout = window.setTimeout;
       var setInterval = window.setInterval;
+      var onerror = window.onerror;
       integration = new Integration();
       var noop = function(){};
       window.setTimeout = noop;
@@ -503,7 +504,7 @@ describe('integration', function(){
       integration.reset();
       assert(setTimeout == window.setTimeout);
       assert(setInterval == window.setInterval);
-      assert(null == window.onerror);
+      assert(onerror == window.onerror);
       assert(null == window.onload);
     });
   });


### PR DESCRIPTION
mocha uses .onerror to report uncaught exceptions.

cc @lancejpollard 
