### PR TITLE
.load(): respect errors

### DIFF
--- a/lib/protos.js
+++ b/lib/protos.js
@@ -204,6 +204,7 @@ exports.load = function(name, locals, fn){
   var template = this.templates[name];
   if (!template) throw new Error(fmt('template "%s" not defined.', name));
   var attrs = render(template, locals);
+  var self = this;
   var el;
 
   switch (template.type) {
@@ -213,7 +214,10 @@ exports.load = function(name, locals, fn){
       el = loadImage(attrs, fn);
       break;
     case 'script':
-      el = loadScript(attrs, fn);
+      el = loadScript(attrs, function(err){
+        if (!err) return fn();
+        self.debug('error loading "%s" error="%s"', self.name, err);
+      });
       // TODO: hack until refactoring load-script
       delete attrs.src;
       each(attrs, function(key, val){

--- a/test/index.js
+++ b/test/index.js
@@ -212,7 +212,8 @@ describe('integration', function(){
   describe('#load', function(){
     beforeEach(function(){
       Integration.tag('example-img', '<img src="/{{name}}.png">')
-      Integration.tag('example-script', '<script src="http://ajax.googleapis.com/ajax/libs/jquery/{{version}}/jquery.min.js"></script>');
+      Integration.tag('example-script', '<script src="https://ajax.googleapis.com/ajax/libs/jquery/{{version}}/jquery.min.js"></script>');
+      Integration.tag('404', '<script src="https://ajax.googleapis.com/ajax/libs/jquery/0/jquery.min.js"></script>');
       integration = new Integration();
       spy(integration, 'load');
     });
@@ -229,10 +230,22 @@ describe('integration', function(){
       });
     });
 
+    it('should not callback on error', function(done){
+      integration.debug = function(){
+        var args = [].slice.call(arguments);
+        var msg = args.shift().replace(/%s/g, function(){ return args.shift(); });
+        assert.equal(msg, 'error loading "Name" error="Error: failed to load the script "https://ajax.googleapis.com/ajax/libs/jquery/0/jquery.min.js""');
+        done();
+      };
+      integration.load('404', function(){
+        done(new Error('shouldnt callback on error'));
+      });
+    });
+
     it('should load script', function (done) {
       integration.load('example-script', { version: '1.11.1' }, function(){
         var script = integration.load.returns[0];
-        assert.equal('http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js', script.src);
+        assert.equal('https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js', script.src);
         done();
       });
     });


### PR DESCRIPTION
The previous integration proto used to propagate errors to the integration
itself, but after the refactor it stopped, this is the easiest solution
because most integrations do stuff like `this.load(this.ready)` or dont expect an error
to happen at all (no `func(err){ return fn(err); }`)

solves: #26 #28 (and all the tickets they link to)

cc @calvinfo @lancejpollard @ianstormtaylor 
