### PR TITLE
Fix Integration.prototype.map regression and add test

### DIFF
--- a/lib/protos.js
+++ b/lib/protos.js
@@ -88,41 +88,51 @@ exports.track = function(track){};
 /* eslint-enable no-unused-vars */
 
 /**
- * Get events that match `str`.
- *
- * Examples:
- *
- *    events = { my_event: 'a4991b88' }
- *    .map(events, 'My Event');
- *    // => ["a4991b88"]
- *    .map(events, 'whatever');
- *    // => []
- *
- *    events = [{ key: 'my event', value: '9b5eb1fa' }]
- *    .map(events, 'my_event');
- *    // => ["9b5eb1fa"]
- *    .map(events, 'whatever');
- *    // => []
+ * Get events that match `event`.
  *
  * @api public
- * @param {string} event
- * @return {Array}
+ * @param {Object|Object[]} events An object or array of objects pulled from
+ * settings.mapping.
+ * @param {string} event The name of the event whose metdata we're looking for.
+ * @return {Array} An array of settings that match the input `event` name.
+ * @example
+ * var events = { my_event: 'a4991b88' };
+ * .map(events, 'My Event');
+ * // => ["a4991b88"]
+ * .map(events, 'whatever');
+ * // => []
+ *
+ * var events = [{ key: 'my event', value: '9b5eb1fa' }];
+ * .map(events, 'my_event');
+ * // => ["9b5eb1fa"]
+ * .map(events, 'whatever');
+ * // => []
  */
 
-exports.map = function(obj, event){
+exports.map = function(events, event){
   var normalizedEvent = normalize(event);
 
-  return foldl(function(acc, val, key) {
-    if (type(obj) === 'array') {
-      key = val[key];
+  return foldl(function(matchingEvents, val, key, events) {
+    // If true, this is a `mixed` value, which is structured like so:
+    //     { key: 'testEvent', value: { event: 'testEvent', someValue: 'xyz' } }
+    // We need to extract the key, which we use to match against
+    // `normalizedEvent`, and return `value` as part of `matchingEvents` if that
+    // match succeds.
+    if (type(events) === 'array') {
+      // If there's no key attached to this event mapping (unusual), skip this
+      // item.
+      if (!val.key) return matchingEvents;
+      // Extract the key and value from the `mixed` object.
+      key = val.key;
+      val = val.value;
     }
 
-    if (key && normalize(key) === normalizedEvent) {
-      acc.push(val);
+    if (normalize(key) === normalizedEvent) {
+      matchingEvents.push(val);
     }
 
-    return acc;
-  }, [], obj);
+    return matchingEvents;
+  }, [], events);
 };
 
 /**

--- a/test/index.js
+++ b/test/index.js
@@ -387,6 +387,14 @@ describe('integration', function(){
         assert(['4cff6219', '4426d54'], integration.map(obj, 'baz'));
       });
 
+      it('should return an array with the object on match when handling `mixed` values', function(){
+        var events = [
+          { key: 'testEvent', value: { event: 'testEvent', mtAdId: 'mt-ad-id', mtId: 'mt-id' } },
+          { key: 'testEvent2', value: { event: 'testEvent2', mtAdId: 'mt-ad-id', mtId: 'mt-id' } }
+        ];
+        assert.deepEqual(integration.map(events, 'testEvent'), [{ event: 'testEvent', mtAdId: 'mt-ad-id', mtId: 'mt-id' }]);
+      });
+
       it('should use to-no-case to match keys', function(){
         var obj = [{ key: 'My Event', value: 'a35bd696' }];
         assert(['a35bd696'], integration.map(obj, 'my_event'));


### PR DESCRIPTION
Our pre-existing test harness didn't cover the `mixed` metadata type,
and so a refactor I did yesterday caused a regression where events that
should have matched out of a mixed mapping were not returned.

This fixes that regression and adds a test for it.