### PR TITLE
Remove window.setTimeout,setInterval restoration

### DIFF
--- a/lib/protos.js
+++ b/lib/protos.js
@@ -35,8 +35,6 @@ var noop = function noop() {};
 
 var onerror = window.onerror;
 var onload = null;
-var setInterval = window.setInterval;
-var setTimeout = window.setTimeout;
 
 /**
  * Mixin emitter.
@@ -234,8 +232,6 @@ exports.reset = function() {
     window[this.globals[i]] = undefined;
   }
 
-  window.setTimeout = setTimeout;
-  window.setInterval = setInterval;
   window.onerror = onerror;
   window.onload = onload;
 };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -547,18 +547,12 @@ describe('integration', function() {
       integration = new Integration();
 
       var noop = function() {};
-      var setTimeout = window.setTimeout;
-      var setInterval = window.setInterval;
       var onerror = window.onerror;
-      window.setTimeout = noop;
-      window.setInterval = noop;
       window.onerror = noop;
       window.onload = noop;
 
       integration.reset();
 
-      assert(window.setTimeout === setTimeout);
-      assert(window.setInterval === setInterval);
       assert(window.onerror === onerror);
       assert(window.onload === onload);
     });


### PR DESCRIPTION
I'm not entirely sure why we ever added this, but clear-globals does it
anyway. Right now it's interfering with timer/clock mocking.