### PR TITLE
Replaced ndhoule clone with lodash deepclone

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,9 @@
+
+3.2.1 / 2018-02-06
+==================
+
+  * Replace ndhoule clone with lodash deepclone to handle circular references in objects
+
 3.2.0 / 2016-11-07
 ==================
 

--- a/karma.conf.ci.js
+++ b/karma.conf.ci.js
@@ -33,16 +33,6 @@ var customLaunchers = {
     browserName: 'safari',
     version: '9.0'
   },
-  sl_ie_7: {
-    base: 'SauceLabs',
-    browserName: 'internet explorer',
-    version: '7'
-  },
-  sl_ie_8: {
-    base: 'SauceLabs',
-    browserName: 'internet explorer',
-    version: '8'
-  },
   sl_ie_9: {
     base: 'SauceLabs',
     browserName: 'internet explorer',

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,6 @@
  */
 
 var bind = require('component-bind');
-var clone = require('@ndhoule/clone');
 var cloneDeep = require('lodash.clonedeep');
 var debug = require('debug');
 var defaults = require('@ndhoule/defaults');

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,7 @@
 
 var bind = require('component-bind');
 var clone = require('@ndhoule/clone');
+var cloneDeep = require('lodash.clonedeep');
 var debug = require('debug');
 var defaults = require('@ndhoule/defaults');
 var extend = require('@ndhoule/extend');
@@ -35,7 +36,7 @@ function createIntegration(name) {
       return options.addIntegration(Integration);
     }
     this.debug = debug('analytics:integration:' + slug(name));
-    this.options = defaults(clone(options) || {}, this.defaults);
+    this.options = defaults(cloneDeep(options) || {}, this.defaults);
     this._queue = [];
     this.once('ready', bind(this, this.flush));
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@segment/analytics.js-integration",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Base factory for analytics.js integrations",
   "keywords": [
     "analytics.js",
@@ -40,7 +40,8 @@
     "load-iframe": "^1.0.0",
     "next-tick": "^0.2.2",
     "slug-component": "^1.1.0",
-    "to-no-case": "^0.1.3"
+    "to-no-case": "^0.1.3",
+    "lodash.clonedeep": "4.5.0"
   },
   "devDependencies": {
     "@segment/eslint-config": "^3.1.1",


### PR DESCRIPTION
After the changes in
https://github.com/segmentio/analytics.js-private/pull/210
https://github.com/segmentio/snippet/pull/27
, the form that object representations of options can take will become much more dynamic due to their being directly passed in by the user. While testing, I found that objects containing circular references broke ndhoule clone as they caused a recursive overflow. Lodash's implementation handles this case and is generally better tested and maintained so should replace the ndhoule version.