### PR TITLE
Switch from lodash clone to cloning via extend

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,9 @@
 
+3.2.2 / 2018-02-09
+==================
+
+  * Replace lodash deepclone with extend to lower ajs size
+
 3.2.1 / 2018-02-06
 ==================
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,10 +5,9 @@
  */
 
 var bind = require('component-bind');
-var cloneDeep = require('lodash.clonedeep');
 var debug = require('debug');
 var defaults = require('@ndhoule/defaults');
-var extend = require('@ndhoule/extend');
+var extend = require('extend');
 var slug = require('slug-component');
 var protos = require('./protos');
 var statics = require('./statics');
@@ -35,7 +34,9 @@ function createIntegration(name) {
       return options.addIntegration(Integration);
     }
     this.debug = debug('analytics:integration:' + slug(name));
-    this.options = defaults(cloneDeep(options) || {}, this.defaults);
+    var cloned = {};
+    extend(true, cloned, options);
+    this.options = defaults(cloned || {}, this.defaults);
     this._queue = [];
     this.once('ready', bind(this, this.flush));
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -34,9 +34,9 @@ function createIntegration(name) {
       return options.addIntegration(Integration);
     }
     this.debug = debug('analytics:integration:' + slug(name));
-    var cloned = {};
-    extend(true, cloned, options);
-    this.options = defaults(cloned || {}, this.defaults);
+    var clonedOpts = {};
+    extend(true, clonedOpts, options); // deep clone options
+    this.options = defaults(clonedOpts || {}, this.defaults);
     this._queue = [];
     this.once('ready', bind(this, this.flush));
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@segment/analytics.js-integration",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Base factory for analytics.js integrations",
   "keywords": [
     "analytics.js",

--- a/package.json
+++ b/package.json
@@ -36,12 +36,12 @@
     "component-emitter": "^1.2.0",
     "debug": "^2.2.0",
     "domify": "^1.4.0",
+    "extend": "3.0.1",
     "is": "^3.1.0",
     "load-iframe": "^1.0.0",
     "next-tick": "^0.2.2",
     "slug-component": "^1.1.0",
-    "to-no-case": "^0.1.3",
-    "lodash.clonedeep": "4.5.0"
+    "to-no-case": "^0.1.3"
   },
   "devDependencies": {
     "@segment/eslint-config": "^3.1.1",


### PR DESCRIPTION
Lodash clone is a massive dependency. `extend` is much smaller and still results in correct deep cloning with circular references.