### PR TITLE
Fix test that verifies invoke error behaviour.

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -293,6 +293,7 @@ describe('integration', function() {
     });
 
     it('should catch errors when it calls', function() {
+      integration.emit('ready');
       integration.initialize();
       integration.invoke('page', 'name');
     });


### PR DESCRIPTION
This test is supposed to verify that when the underlying method throws an error, `invoke` handles it gracefully and suppreses the error. However in this test the integration was never "ready". Under this condition, the integration bails on the ready check before (`  if (!this._ready) return this.queue(method, args);`), and never calls the underlying integration methods. This causes the error path to never be tested.

The fix is to mark the integration as ready before calling invoke. This ensures that the broken `page` method we've setup for this test is invoked.

This was only a test bug (i.e. the behaviour was still correct) and hence was likely not noticed until now.

I discovered this when I was making the changes
https://paper.dropbox.com/doc/Analytics.js-Metrics-SDD-1hAD90lqGS4aZxHAHYPu7#:h2=analytics.js-integration and didn't understand why my changes didn't break the existing tests.

Note that I'll actually be removing the error suppression behaviour later  as described in the SDD, but wanted to the fix the existing tests first before submitting my changes.
