### PR TITLE
Don't swallow integration errors

### DIFF
--- a/lib/protos.js
+++ b/lib/protos.js
@@ -174,16 +174,9 @@ exports.invoke = function(method) {
   if (!this[method]) return;
   var args = Array.prototype.slice.call(arguments, 1);
   if (!this._ready) return this.queue(method, args);
-  var ret;
 
-  try {
-    this.debug('%s with %o', method, args);
-    ret = this[method].apply(this, args);
-  } catch (e) {
-    this.debug('error %o calling %s with %o', e, method, args);
-  }
-
-  return ret;
+  this.debug('%s with %o', method, args);
+  return this[method].apply(this, args);
 };
 
 /**

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -299,10 +299,12 @@ describe('integration', function() {
       assert(integration.track.calledWith('event'));
     });
 
-    it('should catch errors when it calls', function() {
+    it('should throw errors if the integration errors', function() {
       integration.emit('ready');
       integration.initialize();
-      integration.invoke('page', 'name');
+      assert['throws'](function() {
+        integration.invoke('page', 'name');
+      }, Error, 'Should not swallow exceptions');
     });
 
     it('should return the returned value', function(done) {


### PR DESCRIPTION
Same as https://github.com/segmentio/analytics.js-integration/pull/60 but for 2.x.

As part of adding client side metrics, we want to propagate errors to analytics.js-core so that it can capture them.

https://paper.dropbox.com/doc/Analytics.js-Metrics-SDD-1hAD90lqGS4aZxHAHYPu7#:h2=analytics.js-integration

analytics.js-core has already been updated to capture errors when invoking integrations (segmentio/analytics.js-core#66).