### PR TITLE
remove after dependency

### DIFF
--- a/lib/protos.js
+++ b/lib/protos.js
@@ -334,14 +334,12 @@ exports._wrapInitialize = function() {
 
 exports._wrapPage = function() {
   var page = this.page;
+  var initialPageSkipped = false;
   this.page = function() {
-    if (this._assumesPageview) {
-      if (this._initialPageSkipped) return page.apply(this, arguments);
-
-      this._initialPageSkipped = true;
+    if (this._assumesPageview && !initialPageSkipped) {
+      initialPageSkipped = true;
       return;
     }
-
     return page.apply(this, arguments);
   };
 };

--- a/lib/protos.js
+++ b/lib/protos.js
@@ -338,7 +338,8 @@ exports._wrapPage = function() {
     if (this._assumesPageview) {
       if (this._initialPageSkipped) return page.apply(this, arguments);
 
-      return this._initialPageSkipped = true;
+      this._initialPageSkipped = true;
+      return;
     }
 
     return page.apply(this, arguments);

--- a/lib/protos.js
+++ b/lib/protos.js
@@ -5,7 +5,6 @@
  */
 
 var Emitter = require('component-emitter');
-var after = require('@ndhoule/after');
 var each = require('@ndhoule/each');
 var events = require('analytics-events');
 var every = require('@ndhoule/every');
@@ -334,8 +333,16 @@ exports._wrapInitialize = function() {
  */
 
 exports._wrapPage = function() {
-  // Noop the first page call if integration assumes pageview
-  if (this._assumesPageview) return this.page = after(2, this.page);
+  var page = this.page;
+  this.page = function() {
+    if (this._assumesPageview) {
+      if (this._initialPageSkipped) return page.apply(this, arguments);
+
+      return this._initialPageSkipped = true;
+    }
+
+    return page.apply(this, arguments);
+  };
 };
 
 /**

--- a/lib/statics.js
+++ b/lib/statics.js
@@ -83,7 +83,7 @@ exports.global = function(key) {
 
 exports.assumesPageview = function() {
   this.prototype._assumesPageview = true;
-  this.prototype._firstPageSkipped = false;
+  this.prototype._initialPageSkipped = false;
   return this;
 };
 

--- a/lib/statics.js
+++ b/lib/statics.js
@@ -83,7 +83,6 @@ exports.global = function(key) {
 
 exports.assumesPageview = function() {
   this.prototype._assumesPageview = true;
-  this.prototype._initialPageSkipped = false;
   return this;
 };
 

--- a/lib/statics.js
+++ b/lib/statics.js
@@ -83,7 +83,7 @@ exports.global = function(key) {
 
 exports.assumesPageview = function() {
   this.prototype._assumesPageview = true;
-  this.protoype._firstPageSkipped = false;
+  this.prototype._firstPageSkipped = false;
   return this;
 };
 

--- a/lib/statics.js
+++ b/lib/statics.js
@@ -83,6 +83,7 @@ exports.global = function(key) {
 
 exports.assumesPageview = function() {
   this.prototype._assumesPageview = true;
+  this.protoype._firstPageSkipped = false;
   return this;
 };
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   },
   "homepage": "https://github.com/segmentio/analytics.js-integration#readme",
   "dependencies": {
-    "@ndhoule/after": "^1.0.0",
     "@ndhoule/clone": "^1.0.0",
     "@ndhoule/defaults": "^2.0.1",
     "@ndhoule/each": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,16 +2,6 @@
 # yarn lockfile v1
 
 
-"@ndhoule/after@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@ndhoule/after/-/after-1.0.0.tgz#e6d86d121448247ac742ff3a61c63fae83ee1191"
-  dependencies:
-    "@ndhoule/arity" "^2.0.0"
-
-"@ndhoule/arity@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@ndhoule/arity/-/arity-2.0.0.tgz#26bfa0b9755ced9aea819d4e6e7a93db27a5b658"
-
 "@ndhoule/clone@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@ndhoule/clone/-/clone-1.0.0.tgz#0f68394a95008cf360370e101924564a70927afc"


### PR DESCRIPTION
For https://segment.atlassian.net/browse/LIB-1430

This PR removes the dependency on "after" which violated customer CSP with a new Function() call.