### PR TITLE
Pin domify 1.4.1 to fix potential XSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "component-bind": "^1.0.0",
     "component-emitter": "^1.2.0",
     "debug": "^2.2.0",
-    "domify": "^1.4.0",
+    "domify": "^1.4.1",
     "extend": "^3.0.2",
     "is": "^3.1.0",
     "load-iframe": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@segment/analytics.js-integration",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "description": "Base factory for analytics.js integrations",
   "keywords": [
     "analytics.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1250,9 +1250,10 @@ domain-browser@~1.1.0:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.1.7.tgz#867aa4b093faa05f1de08c06f4d7b21fdf8698bc"
 
-domify@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/domify/-/domify-1.4.0.tgz#11483617f764f8695975b4bdc79b14f0803b629b"
+domify@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/domify/-/domify-1.4.1.tgz#2e1e813019646715deeb8d3c5de4d3ef7bddd07e"
+  integrity sha512-x18nuiDHMCZGXr4KJSRMf/TWYtiaRo6RX8KN9fEbW54mvbQ6pieUuerC2ahBg+kEp1wycFj8MPUI0WkIOw5E9w==
 
 duplexer2@^0.1.2, duplexer2@~0.1.0, duplexer2@~0.1.2:
   version "0.1.4"


### PR DESCRIPTION
This PR upgrades `domify` to 1.4.1 to fix a potential XSS via prototype pollution.

See https://github.com/component/domify/pull/48 for more details