### PR TITLE
Upgrade analytics-events package to 2.2.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@ndhoule/includes": "^2.0.1",
     "@segment/fmt": "^1.0.0",
     "@segment/load-script": "^1.0.1",
-    "analytics-events": "^2.0.2",
+    "analytics-events": "^2.2.5",
     "component-bind": "^1.0.0",
     "component-emitter": "^1.2.0",
     "debug": "^2.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -187,9 +187,10 @@ amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
 
-analytics-events@^2.0.2:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/analytics-events/-/analytics-events-2.2.0.tgz#f00f55946940a6357809582f6fded6ab80034b84"
+analytics-events@^2.2.5:
+  version "2.2.5"
+  resolved "https://registry.npmjs.org/analytics-events/-/analytics-events-2.2.5.tgz#7f20217a7b08d3bf719e48b62b0785064e74f71b"
+  integrity sha512-WuuEs52q/mxvM/wvLSdNA71iEqwTSnLodkwnPpzVUYzFuoR1YOujvN09ZMpkcaVhkTBK/rbfPiSpDEDD8FFD6Q==
   dependencies:
     "@ndhoule/foldl" "^2.0.1"
     "@ndhoule/map" "^2.0.1"


### PR DESCRIPTION
Updates `analytics-events` package to v2.2.5, which includes a new video event.